### PR TITLE
[TASK] Make compatible with EXT:solr 9

### DIFF
--- a/Resources/Private/Templates/Search/Results.html
+++ b/Resources/Private/Templates/Search/Results.html
@@ -21,7 +21,7 @@
 
 			<div class="tx-solr-search-form col-lg-2 hidden-xs">&nbsp;</div>
 			<div class="col-lg-2 hidden-xs">
-				<f:if condition="{hasSearched}">
+				<f:if condition="{resultSet.hasSearched}">
 					<f:if condition="{resultSet.usedSearchRequest.contextTypoScriptConfiguration.searchSorting}">
 						<f:render partial="Result/Sorting" section="Sorting" arguments="{resultSet:resultSet}" />
 					</f:if>
@@ -94,7 +94,7 @@
 
 		<div class="row">
 			<div class="col-md-12">
-				<f:if condition="{hasSearched}">
+				<f:if condition="{resultSet.hasSearched}">
 					<f:if condition="{resultSet.searchresults.hasGroups}">
 						<f:then>
 							<f:for each="{resultSet.searchresults.groups}" as="group">
@@ -130,7 +130,7 @@
 
 <f:section name="extra">
 	<div id="tx-solr-search-functions">
-		<f:if condition="{hasSearched}">
+		<f:if condition="{resultSet.hasSearched}">
 			<f:if condition="{resultSet.usedSearchRequest.contextTypoScriptConfiguration.searchFaceting}">
 				<f:render partial="Result/Facets" section="Facets" arguments="{resultSet:resultSet}" />
 			</f:if>

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -2,7 +2,7 @@
 $EM_CONF[$_EXTKEY] = array(
     'title' => 'Apache Solr for TYPO3 - Fluid Frontend Customizing',
     'description' => 'This extension shows, how to customize solrfluid with custom templates',
-    'version' => '3.3.0',
+    'version' => '4.0.0',
     'state' => 'stable',
     'category' => 'plugin',
     'author' => 'Timo Hund, Markus Friedrich',
@@ -16,10 +16,10 @@ $EM_CONF[$_EXTKEY] = array(
     'constraints' => array(
         'depends' => array(
             'scheduler' => '',
-            'solr' => '8.0.0-',
-            'extbase' => '8.7.0-9.3.99',
-            'fluid' => '8.7.0-9.3.99',
-            'typo3' => '8.7.0-9.3.99'
+            'solr' => '9.0.0-',
+            'extbase' => '8.7.0-9.5.99',
+            'fluid' => '8.7.0-9.5.99',
+            'typo3' => '8.7.0-9.5.99'
         ),
         'conflicts' => array(),
         'suggests' => array(


### PR DESCRIPTION
* Replaces {hasSearched} with {resultSet.hasSearched}
* Allows to install with TYPO3
* Set minimum required TYPO3 version to 9